### PR TITLE
Fix search-results being cut off viewport

### DIFF
--- a/build/css/index.css
+++ b/build/css/index.css
@@ -125,7 +125,7 @@
   top: 50px;
   padding: 5px;
   right: 0px;
-  width: 200px;
+  width: 184px;
   background-color: white;
   border: 1px solid #e6e6e6;
   border-radius: 3px;

--- a/src/less/content.less
+++ b/src/less/content.less
@@ -126,7 +126,7 @@
   top: 50px;
   padding: 5px;
   right: 0px;
-  width: 200px;
+  width: 184px;
   background-color: white;
   border: 1px solid lighten(gray, 40%);
   border-radius: 3px;


### PR DESCRIPTION
Change width of `.cate-search-result` from `200px` to `184px` so that when a user searches for a category topic, the results aren't being cut on the left side of the screen.

This closes #108.